### PR TITLE
Add IntervalSetFunctor to intDomain.mli interface

### DIFF
--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -370,6 +370,8 @@ module Lifted : IkindUnawareS with type t = [`Top | `Lifted of int64 | `Bot] and
 
 module IntervalFunctor(Ints_t : IntOps.IntOps): S with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) option
 
+module IntervalSetFunctor(Ints_t : IntOps.IntOps): S with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) list
+
 module Interval32 :Y with (* type t = (IntOps.Int64Ops.t * IntOps.Int64Ops.t) option and *) type int_t = IntOps.Int64Ops.t
 
 module BigInt:


### PR DESCRIPTION
Co-authored-by: mfarider <118011736+mfarider@users.noreply.github.com>