### PR TITLE
Suppress ovflow fix

### DIFF
--- a/docs/user-guide/annotating.md
+++ b/docs/user-guide/annotating.md
@@ -21,10 +21,13 @@ The attribute `goblint_context` can be used to fine-tune function contexts.
 The following string arguments are supported:
 
 1. `base.interval`/`base.no-interval` to override the `ana.base.context.interval` option.
-2. `base.int`/`base.no-int` to override the `ana.base.context.interval` option.
-3. `base.non-ptr`/`base.no-non-ptr` to override the `ana.base.context.non-ptr` option.
-4. `relation.context`/`relation.no-context` to override the `ana.relation.context` option.
-5. `widen`/`no-widen` to override the `ana.context.widen` option.
+2. `base.interval_set`/`base.no-interval_set` to override the `ana.base.context.interval_set` option.
+3. `base.int`/`base.no-int` to override the `ana.base.context.interval` option.
+4. `base.non-ptr`/`base.no-non-ptr` to override the `ana.base.context.non-ptr` option.
+5. `relation.context`/`relation.no-context` to override the `ana.relation.context` option.
+6. `widen`/`no-widen` to override the `ana.context.widen` option.
+
+
 
 ### Apron attributes
 The Apron library can be set to only track variables with the attribute `goblint_apron_track`

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -595,6 +595,8 @@ struct
 
   let drop_interval = CPA.map (function `Int x -> `Int (ID.no_interval x) | x -> x)
 
+  let drop_intervalSet = CPA.map (function `Int x -> `Int (ID.no_intervalSet x) | x -> x )
+
   let context (fd: fundec) (st: store): store =
     let f keep drop_fn (st: store) = if keep then st else { st with cpa = drop_fn st.cpa} in
     st |>
@@ -604,6 +606,7 @@ struct
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.non-ptr" ~removeAttr:"base.no-non-ptr" ~keepAttr:"base.non-ptr" fd) drop_non_ptrs
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.int" ~removeAttr:"base.no-int" ~keepAttr:"base.int" fd) drop_ints
     %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.interval" ~removeAttr:"base.no-interval" ~keepAttr:"base.interval" fd) drop_interval
+    %> f (ContextUtil.should_keep ~isAttr:GobContext ~keepOption:"ana.base.context.interval_set" ~removeAttr:"base.no-interval_set" ~keepAttr:"base.interval_set" fd) drop_intervalSet
 
   let context_cpa fd (st: store) = (context fd st).cpa
 

--- a/src/autoTune.ml
+++ b/src/autoTune.ml
@@ -129,8 +129,8 @@ let disableIntervalContextsInRecursiveFunctions () =
   ResettableLazy.force functionCallMaps |> fun (x,_,_) -> x |> FunctionCallMap.iter (fun f set ->
       (*detect direct recursion and recursion with one indirection*)
       if FunctionSet.mem f set || (not @@ FunctionSet.disjoint (calledFunctions f) (callingFunctions f)) then (
-        print_endline ("function " ^ (f.vname) ^" is recursive, disable interval context");
-        f.vattr <- addAttributes (f.vattr) [Attr ("goblint_context",[AStr "base.no-interval"; AStr "relation.no-context"])];
+        print_endline ("function " ^ (f.vname) ^" is recursive, disable interval and intervalSet contexts");
+        f.vattr <- addAttributes (f.vattr) [Attr ("goblint_context",[AStr "base.no-interval"; AStr "base.no-interval_set"; AStr "relation.no-context"])];
       )
     )
 

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -535,21 +535,6 @@ struct
     | Some (a, b) ->
       if a = b && b = i then `Eq else if Ints_t.compare a i <= 0 && Ints_t.compare i b <=0 then `Top else `Neq
 
-  let set_overflow_flag ~cast ~underflow ~overflow ik =
-    let signed = Cil.isSigned ik in
-    if !GU.postsolving && signed && not cast then (
-      Goblintutil.svcomp_may_overflow := true);
-
-    let sign = if signed then "Signed" else "Unsigned" in
-    match underflow, overflow with
-    | true, true ->
-      M.warn ~category:M.Category.Integer.overflow ~tags:[CWE 190; CWE 191] "%s integer overflow and underflow" sign
-    | true, false ->
-      M.warn ~category:M.Category.Integer.overflow ~tags:[CWE 191] "%s integer underflow" sign
-    | false, true ->
-      M.warn ~category:M.Category.Integer.overflow ~tags:[CWE 190] "%s integer overflow" sign
-    | false, false -> assert false
-
   let norm ?(suppress_ovwarn=false) ?(cast=false) ik = function None -> None | Some (x,y) ->
     if Ints_t.compare x y > 0 then None
     else (
@@ -592,7 +577,7 @@ struct
     match x, y with
     | None, z | z, None -> z
     | Some (x1,x2), Some (y1,y2) -> norm ik @@ Some (Ints_t.min x1 y1, Ints_t.max x2 y2)
-
+ 
   let meet ik (x:t) y =
     match x, y with
     | None, z | z, None -> None
@@ -1114,10 +1099,11 @@ struct
   let meet ik (x: t) (y: t): t = 
     two_interval_sets_to_events x y |> 
     combined_event_list  `Meet |> 
-    events_to_intervals |> 
-    remove_empty_gaps
+    events_to_intervals 
 
-  let to_int = function [(x, y)] when Ints_t.compare x y = 0 -> Some x | _ -> None
+  let to_int = function 
+    | [(x, y)] when Ints_t.compare x y = 0 -> Some x 
+    | _ -> None
 
   let zero = [(Ints_t.zero, Ints_t.zero)]
   let one = [(Ints_t.one, Ints_t.one)]

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -3131,6 +3131,7 @@ module IntDomTupleImpl = struct
 
   (* The Interval domain can lead to too many contexts for recursive functions (top is [min,max]), but we don't want to drop all ints as with `ana.base.context.int`. TODO better solution? *)
   let no_interval = Tuple5.map2 (const None)
+  let no_intervalSet = Tuple5.map5 (const None)
 
   type 'a m = (module S with type t = 'a)
   type 'a m2 = (module S with type t = 'a and type int_t = int_t )
@@ -3558,6 +3559,7 @@ struct
   let top () = failwith "top in IntDomTuple not supported. Use top_of instead."
   let no_interval (x: I.t) = {x with v = IntDomTupleImpl.no_interval x.v}
 
+  let no_intervalSet (x: I.t) = {x with v = IntDomTupleImpl.no_intervalSet x.v}
 end
 
 let of_const (i, ik, str) = IntDomTuple.of_int ik i

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -273,6 +273,37 @@ sig
 end
 (** Interface of IntDomain implementations taking an ikind for arithmetic operations *)
 
+module type SOverFlow = 
+sig
+
+  include S
+
+  val add : ?no_ov:bool -> Cil.ikind ->  t -> t -> t * bool * bool * bool
+
+  val sub : ?no_ov:bool -> Cil.ikind ->  t -> t -> t * bool * bool * bool
+
+  val mul : ?no_ov:bool -> Cil.ikind ->  t -> t -> t * bool * bool * bool
+
+  val div : ?no_ov:bool -> Cil.ikind ->  t -> t -> t * bool * bool * bool
+
+  val neg : ?no_ov:bool -> Cil.ikind ->  t -> t * bool * bool * bool
+  
+  val cast_to : ?torg:Cil.typ -> ?no_ov:bool -> Cil.ikind -> t -> t * bool * bool * bool
+
+  val of_int : Cil.ikind -> int_t -> t * bool * bool * bool
+
+  val of_interval: ?suppress_ovwarn:bool -> Cil.ikind -> int_t * int_t -> t * bool  * bool * bool
+
+  val starting : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t * bool  * bool * bool
+  val ending : ?suppress_ovwarn:bool -> Cil.ikind -> int_t -> t * bool * bool * bool
+
+  val shift_left : Cil.ikind -> t -> t -> t * bool * bool * bool
+
+  val shift_right: Cil.ikind -> t -> t -> t * bool * bool * bool
+
+
+end
+
 module OldDomainFacade (Old : IkindUnawareS with type int_t = int64) : S with type int_t = IntOps.BigIntOps.t and type t = Old.t
 (** Facade for IntDomain implementations that do not implement the interface where arithmetic functions take an ikind parameter. *)
 
@@ -370,9 +401,9 @@ module FlattenedBI : IkindUnawareS with type t = [`Top | `Lifted of IntOps.BigIn
 module Lifted : IkindUnawareS with type t = [`Top | `Lifted of int64 | `Bot] and type int_t = int64
 (** Artificially bounded integers in their natural ordering. *)
 
-module IntervalFunctor(Ints_t : IntOps.IntOps): S with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) option
+module IntervalFunctor(Ints_t : IntOps.IntOps): SOverFlow with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) option
 
-module IntervalSetFunctor(Ints_t : IntOps.IntOps): S with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) list
+module IntervalSetFunctor(Ints_t : IntOps.IntOps): SOverFlow with type int_t = Ints_t.t and type t = (Ints_t.t * Ints_t.t) list
 
 module Interval32 :Y with (* type t = (IntOps.Int64Ops.t * IntOps.Int64Ops.t) option and *) type int_t = IntOps.Int64Ops.t
 
@@ -382,9 +413,9 @@ module BigInt:
     val cast_to: Cil.ikind -> Z.t -> Z.t
   end
 
-module Interval : S with type int_t = IntOps.BigIntOps.t
+module Interval : SOverFlow with type int_t = IntOps.BigIntOps.t
 
-module IntervalSet : S with type int_t = IntOps.BigIntOps.t
+module IntervalSet : SOverFlow with type int_t = IntOps.BigIntOps.t
 
 module Congruence : S with type int_t = IntOps.BigIntOps.t
 

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -320,6 +320,7 @@ module IntDomWithDefaultIkind (I: Y) (Ik: Ikind) : Y with type t = I.t and type 
 module IntDomTuple : sig
   include Z
   val no_interval: t -> t
+  val no_intervalSet: t -> t
   val ikind: t -> ikind
 end
 

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -595,6 +595,13 @@
                     "Integer values of the Interval domain in function contexts.",
                   "type": "boolean",
                   "default": true
+                },
+                "interval_set": {
+                  "title": "ana.base.context.interval_set",
+                  "description":
+                    "Integer values of the IntervalSet domain in function contexts.",
+                  "type": "boolean",
+                  "default": true
                 }
               },
               "additionalProperties": false
@@ -1421,7 +1428,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["base.no-non-ptr", "base.non-ptr", "base.no-int", "base.int", "base.no-interval", "base.interval", "relation.no-context", "relation.context", "no-widen", "widen"]
+              "enum": ["base.no-non-ptr", "base.non-ptr", "base.no-int", "base.int", "base.no-interval", "base.no-interval_set","base.interval", "base.interval_set","relation.no-context", "relation.context", "no-widen", "widen"]
             },
             "default": []
           }


### PR DESCRIPTION
We pass down the suppress_ovflow and disable the intervalSet domain if a function is recursive.